### PR TITLE
OPLL Rhythm volume fix

### DIFF
--- a/Firmware/Sources/OPLL2/TemporalMixer.vhd
+++ b/Firmware/Sources/OPLL2/TemporalMixer.vhd
@@ -160,11 +160,11 @@ begin
         
         if rmute = '0' then
           if mdata.sign = '0' then
-            ro <= "1000000000" + (mdata.value&"0");--(10<10+9)
-            ACRO <= ACRO + mdata.value; --*    (16<16+9)
+            ro <= "1000000000" + mdata.value;
+            ACRO <= ACRO + (mdata.value&"0"); --*
           else
-            ro <= "1000000000" - (mdata.value&"0");
-            ACRO <= ACRO - mdata.value; --*
+            ro <= "1000000000" - mdata.value;
+            ACRO <= ACRO - (mdata.value&"0"); --*
           end if;
         else
           ro <= "1000000000";

--- a/Firmware/Sources/OPLL2/vm2413.vhd
+++ b/Firmware/Sources/OPLL2/vm2413.vhd
@@ -25,8 +25,8 @@ package VM2413 is
     FNUM : std_logic_vector(8 downto 0);
   end record;
 
-  function CONV_REGS_VECTOR ( inst : REGS_TYPE ) return REGS_VECTOR_TYPE;
-  function CONV_REGS ( inst_vec : REGS_VECTOR_TYPE ) return REGS_TYPE; 
+  function CONV_REGS_VECTOR ( regs : REGS_TYPE ) return REGS_VECTOR_TYPE;
+  function CONV_REGS ( vec : REGS_VECTOR_TYPE ) return REGS_TYPE; 
 
   subtype VOICE_ID_TYPE is integer range 0 to 37;
   subtype VOICE_VECTOR_TYPE is std_logic_vector(35 downto 0);
@@ -41,8 +41,8 @@ package VM2413 is
     AR, DR, SL, RR : std_logic_vector(3 downto 0);
   end record;
   
-  function CONV_VOICE_VECTOR ( voice : VOICE_TYPE ) return VOICE_VECTOR_TYPE;
-  function CONV_VOICE ( vector : VOICE_VECTOR_TYPE ) return VOICE_TYPE; 
+  function CONV_VOICE_VECTOR ( inst : VOICE_TYPE ) return VOICE_VECTOR_TYPE;
+  function CONV_VOICE ( inst_vec : VOICE_VECTOR_TYPE ) return VOICE_TYPE; 
 
   -- Voice Parameter Types
   subtype AM_TYPE is std_logic; -- AM switch - '0':off  '1':3.70Hz


### PR DESCRIPTION
OPLL rhythm volume is being doubled for the wrong target, resulting in half the volume and other anomalies.
I propose a fix for this problem.

- Sound before modification. Rhythm volume is too low.
    https://twitter.com/uniskie/status/1348628086623854593

- Sound after correction. Sounds like proper rhythmic volume.
    https://twitter.com/uniskie/status/1348628153636278275

- (Reference) Sound of OCM using the same VM2413
    https://twitter.com/uniskie/status/1348629479585796096

I am not proficient in VHDL, so I hope you will fix the bug based on this change.

(Other.
It is a small change, but it is recommended to import the fix for the compilation error that occurs in QuartusII from VM2413.)

( *I had to recreate the request because of an unnecessary file update that had crept in.* )
